### PR TITLE
Fix Makefile for Verilator requires a C++14 or newer error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ DISTRIBUTABLES += $(wildcard presets)
 
 $(VERILATED_PATH)/Vcore.mk: rtl/core.sv
 	mkdir -p build; \
-	verilator --cc $< -Mdir $(VERILATED_PATH) -CFLAGS -fPIC
+    verilator --cc $< -Mdir $(VERILATED_PATH) -CFLAGS -fPIC  -CFLAGS -std=c++17
 
 $(VERILATED_PATH)/$(VERILATED_OBJ): $(VERILATED_PATH)/Vcore.mk
 	make -C $(VERILATED_PATH) -f $(VERILATED_MK)


### PR DESCRIPTION
Added `-std=c++17` flag to Verilator command to fix make error: "Verilator requires a C++14 or newer compiler" https://github.com/apfaudio/verilog-vcvrack/issues/5